### PR TITLE
CIVICRM-868: Hiding tax field on edit line item form if no tax collected.

### DIFF
--- a/templates/CRM/Lineitemedit/Form/Edit.tpl
+++ b/templates/CRM/Lineitemedit/Form/Edit.tpl
@@ -1,7 +1,7 @@
 {* HEADER *}
 
 {foreach from=$fieldNames item=fieldName}
-<div class="crm-section">
+<div class="crm-section" {if $fieldName == 'tax_amount'}id="crm-section-tax-amount"{/if} {if $fieldName == 'tax_amount' and not $isTaxEnabled}style="display: none;"{/if}>
     <div class="label">{$form.$fieldName.label}</div>
     <div class="content">
       {if in_array($fieldName, array('unit_price', 'line_total', 'tax_amount'))}


### PR DESCRIPTION
This PR is for Issue #14 

## Issue
0.00 tax added for financial types with no tax account

## Steps to reproduce:

1. Turn on Tax & Invoicing then set up a financial type with no tax account - call this e.g. "No Tax calculation"
2. Create a contribution with a single line item using "No Tax calculation" as the financial type.
3. Check the line items using SQL - tax_amount is NULL - correct
4. Edit the Contribution and change a line item
5. Note that tax_amount is 0.00 on this form.
6. Check the line items using SQL - tax_amount is 0.00 - this causes problems with the invoice template ("% GST" with no number) and also account syncing with Xero, which will receive the full amount as tax exclusive (due to 0.00 as a string not being "empty") and add tax on top for accounts tax instead of calculating the percentage of the given amount which is already tax.

## Solution:
Instead of setting default value of tax_amount to 0.00 we set it to NULL, and adding only non-null value fields on edit line item form.  