### PR TITLE
issue#17 Changing line_item quantity and unit price doesn't affect tax amount on both Add and Edit form

### DIFF
--- a/templates/CRM/Lineitemedit/Form/Add.tpl
+++ b/templates/CRM/Lineitemedit/Form/Add.tpl
@@ -40,44 +40,8 @@
           }
         });
       });
-
-      $('#qty', $form).change( function() {
-        var unit_price = $('#unit_price', $form).val();
-        var qty = $('#qty', $form).val();
-        var totalAmount = qty * unit_price;
-        $('#line_total', $form).val(CRM.formatMoney(totalAmount, true));
-        if ($('#tax_amount').length) {
-          var tax_amount = calculateTaxAmount($('#financial_type_id').val());
-          $('#tax_amount', $form).val(CRM.formatMoney(tax_amount, true));
-        }
-      });
-      $('#unit_price', $form).change( function() {
-        var unit_price = $('#unit_price', $form).val();
-        var qty = $('#qty', $form).val();
-        var totalAmount = qty * unit_price;
-        $('#line_total', $form).val(CRM.formatMoney(totalAmount, true));
-        if ($('#tax_amount').length) {
-          var tax_amount = calculateTaxAmount($('#financial_type_id').val());
-          $('#tax_amount', $form).val(CRM.formatMoney(tax_amount, true));
-        }
-      });
-      $('#financial_type_id', $form).change( function() {
-        if ($('#tax_amount').length) {
-          var tax_amount = calculateTaxAmount($(this).val());
-          $('#tax_amount', $form).val(CRM.formatMoney(tax_amount, true));
-        }
-      });
-
-      function calculateTaxAmount(financial_type_id) {
-        var tax_amount = 0;
-        if ($('#tax_amount').length) {
-          var tax_rates = {/literal}{$taxRates}{literal};
-          if (financial_type_id in tax_rates) {
-            tax_amount = (tax_rates[financial_type_id] / 100 ) * $('#line_total').val();
-          }
-        }
-        return tax_amount;
-      }
     });
   </script>
 {/literal}
+
+{include file="CRM/Lineitemedit/Form/CalculateLineitemFields.tpl"}

--- a/templates/CRM/Lineitemedit/Form/CalculateLineItemFields.tpl
+++ b/templates/CRM/Lineitemedit/Form/CalculateLineItemFields.tpl
@@ -1,0 +1,29 @@
+{literal}
+  <script type="text/javascript">
+    CRM.$(function($) {
+      function changeTaxAmount(line_total, financial_type_id) {
+        if ($('#tax_amount').length) {
+          var tax_rates = {/literal}{$taxRates}{literal};
+          var tax_amount = 0;
+          if (financial_type_id in tax_rates) {
+            tax_amount = (tax_rates[financial_type_id] / 100 ) * line_total;
+            $('#tax_amount', $form).val(CRM.formatMoney(tax_amount, true));
+          }
+          else {
+            $('#tax_amount', $form).val('');
+          }
+        }
+      }
+
+      var $form = $('form.{/literal}{$form.formClass}{literal}');
+      $('#qty, #unit_price, #financial_type_id', $form).change( function() {
+        var unit_price = $('#unit_price', $form).val();
+        var qty = $('#qty', $form).val();
+        var totalAmount = CRM.formatMoney((qty * unit_price), true);
+        $('#line_total', $form).val(totalAmount);
+        changeTaxAmount(totalAmount, $('#financial_type_id').val());
+      });
+    });
+
+  </script>
+{/literal}

--- a/templates/CRM/Lineitemedit/Form/Edit.tpl
+++ b/templates/CRM/Lineitemedit/Form/Edit.tpl
@@ -18,33 +18,4 @@
 {include file="CRM/common/formButtons.tpl" location="bottom"}
 </div>
 
-{literal}
-  <script type="text/javascript">
-    CRM.$(function($) {
-      var $form = $('form.{/literal}{$form.formClass}{literal}');
-      $('#qty', $form).change( function() {
-        var unit_price = $('#unit_price', $form).val();
-        var qty = $('#qty', $form).val();
-        var totalAmount = qty * unit_price;
-        $('#line_total', $form).val(CRM.formatMoney(totalAmount, true));
-      });
-      $('#unit_price', $form).change( function() {
-        var unit_price = $('#unit_price', $form).val();
-        var qty = $('#qty', $form).val();
-        var totalAmount = qty * unit_price;
-        $('#line_total', $form).val(CRM.formatMoney(totalAmount, true));
-      });
-      $('#financial_type_id', $form).change( function() {
-        if ($('#tax_amount').length) {
-          var tax_rates = {/literal}{$taxRates}{literal};
-          var financial_type_id = $(this).val();
-          var tax_amount = 0;
-          if (financial_type_id in tax_rates) {
-            tax_amount = (tax_rates[financial_type_id] / 100 ) * $('#line_total').val();
-          }
-          $('#tax_amount', $form).val(CRM.formatMoney(tax_amount, true));
-        }
-      });
-    });
-  </script>
-{/literal}
+{include file="CRM/Lineitemedit/Form/CalculateLineitemFields.tpl"}


### PR DESCRIPTION
Steps to replicate:
1. Enable Sale Tax and create/modify Financial Type that has tax rate. Let say Donation FT has 10% tax rate.
2. Create a contribution choosing a price-field that is configured with Donation FT or simply choose Donation FT and do a backoffice contribution.
3. Go to the edit contribution and change the line-item quantity and/or unit price via Edit form

BEFORE
-----------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/40418035-e6d3433e-5e9e-11e8-93fb-59e00b0efcb3.gif)

AFTER
-----------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/40417991-c7677b28-5e9e-11e8-8a9f-9e4b480c9320.gif)



 