### PR TITLE
Fix case for CalculateLineItemFields.tpl include on Add and Edit tpls.

### DIFF
--- a/templates/CRM/Lineitemedit/Form/Add.tpl
+++ b/templates/CRM/Lineitemedit/Form/Add.tpl
@@ -44,4 +44,4 @@
   </script>
 {/literal}
 
-{include file="CRM/Lineitemedit/Form/CalculateLineitemFields.tpl"}
+{include file="CRM/Lineitemedit/Form/CalculateLineItemFields.tpl"}

--- a/templates/CRM/Lineitemedit/Form/Edit.tpl
+++ b/templates/CRM/Lineitemedit/Form/Edit.tpl
@@ -18,4 +18,4 @@
 {include file="CRM/common/formButtons.tpl" location="bottom"}
 </div>
 
-{include file="CRM/Lineitemedit/Form/CalculateLineitemFields.tpl"}
+{include file="CRM/Lineitemedit/Form/CalculateLineItemFields.tpl"}


### PR DESCRIPTION
Without this fix, the javascript to calculate the line total is not added to the page on systems with case sensitive file names