### PR TITLE
Do not assign taxRates to line edit form (caused cdntaxcalculator conflict)

### DIFF
--- a/CRM/Lineitemedit/Util.php
+++ b/CRM/Lineitemedit/Util.php
@@ -924,7 +924,6 @@ ORDER BY  ps.id, pf.weight ;
     }
     $contributeSettings = Civi::settings()->get('contribution_invoice_settings');
     $form->assign('taxEnabled', (!empty($contributeSettings['invoicing'])));
-    $form->assign('taxRates', json_encode(CRM_Core_PseudoConstant::getTaxRates()));
     $form->assign('lineItemSubmitted', json_encode($submittedValues));
     $form->assign('currency', CRM_Core_DAO::getFieldValue(
       'CRM_Financial_DAO_Currency',


### PR DESCRIPTION
I tested the following uses cases with Symbiotic's [cdntaxcalculator branch](https://github.com/coopsymbiotic/biz.jmaconsulting.cdntaxcalculator):

* From the backend, create a taxable contribution with a priceset that has multiple fields, select one field (text qty), save
* A) Edit the contribution, edit the existing line item, change the quantity, save
* B) Edit the contribution, add a new line item, save.

Without removing this line (assign taxRates), I would always get the 99% tax rate, which is the default global tax rate that I usually set when using cdntaxcalculator. Removing this line fixes the issue.

I also tested without cdntaxcalculator, and everything seemed OK without this line.