### PR TITLE
github#39 add participant name on contribution edit page

### DIFF
--- a/CRM/Lineitemedit/Util.php
+++ b/CRM/Lineitemedit/Util.php
@@ -146,7 +146,7 @@ class CRM_Lineitemedit_Util {
           // for participant line item, add participant name
           if ($lineItem['entity_table'] == 'civicrm_participant') {
             $participant = civicrm_api3('Participant', 'getsingle', ['id' => $lineItem['entity_id']]);
-            $lineItems[$priceSetID][$lineItemID]['field_title'] = $lineItems[$priceSetID][$lineItemID]['field_title'] . ' - ' . $participant['display_name'];
+            $lineItems[$priceSetID][$lineItemID]['label'] = $lineItems[$priceSetID][$lineItemID]['field_title'] . ' - ' . $participant['display_name'];
           }
 
           if (!$isParticipantCount) {

--- a/CRM/Lineitemedit/Util.php
+++ b/CRM/Lineitemedit/Util.php
@@ -143,6 +143,12 @@ class CRM_Lineitemedit_Util {
             );
           }
 
+          // for participant line item, add participant name
+          if ($lineItem['entity_table'] == 'civicrm_participant') {
+            $participant = civicrm_api3('Participant', 'getsingle', ['id' => $lineItem['entity_id']]);
+            $lineItems[$priceSetID][$lineItemID]['field_title'] = $participant['display_name'] . ' - ' . $lineItems[$priceSetID][$lineItemID]['field_title'];
+          }
+
           if (!$isParticipantCount) {
             $lineItems[$priceSetID][$lineItemID]['participant_count'] = '';
           }

--- a/CRM/Lineitemedit/Util.php
+++ b/CRM/Lineitemedit/Util.php
@@ -146,7 +146,7 @@ class CRM_Lineitemedit_Util {
           // for participant line item, add participant name
           if ($lineItem['entity_table'] == 'civicrm_participant') {
             $participant = civicrm_api3('Participant', 'getsingle', ['id' => $lineItem['entity_id']]);
-            $lineItems[$priceSetID][$lineItemID]['field_title'] = $participant['display_name'] . ' - ' . $lineItems[$priceSetID][$lineItemID]['field_title'];
+            $lineItems[$priceSetID][$lineItemID]['field_title'] = $lineItems[$priceSetID][$lineItemID]['field_title'] . ' - ' . $participant['display_name'];
           }
 
           if (!$isParticipantCount) {


### PR DESCRIPTION
See https://github.com/JMAConsulting/biz.jmaconsulting.lineitemedit/issues/39

Before :

![Screenshot_2019-07-05 Edit Contribution - no participant name](https://user-images.githubusercontent.com/372004/60733678-9688ec80-9f1b-11e9-94d6-f52dc2645ac0.png)

After:

![Screenshot_2019-07-05 Edit Contribution - with participant name](https://user-images.githubusercontent.com/372004/60733515-119dd300-9f1b-11e9-8dbe-93899ace2d04.png)
