### PR TITLE
issue#53: Fatal error on editing contribution

### DIFF
--- a/lineitemedit.php
+++ b/lineitemedit.php
@@ -287,6 +287,7 @@ function lineitemedit_civicrm_pre($op, $entity, $entityID, &$params) {
           $taxAmount,
           TRUE, TRUE
         );
+        $entityID = (string) $entityID;
         Civi::cache('lineitemEditor')->set($entityID, $contriParams);
 
         // record financial item on addition of lineitem
@@ -306,6 +307,7 @@ function lineitemedit_civicrm_pre($op, $entity, $entityID, &$params) {
 
 function lineitemedit_civicrm_post($op, $entity, $entityID, &$obj) {
   if ($entity == 'Contribution' && $op == 'edit') {
+    $entityID = (string) $entityID;
     $contriParams = Civi::cache('lineitemEditor')->get($entityID);
     if (!empty($contriParams)) {
       $obj->copyValues($contriParams);


### PR DESCRIPTION
 It seems like the error is originating from line-item editor as it is relying on CRM_Utils_Cache_SqlGroup->get(369711) to fetch the contribution detail but here we are passsing integer parameter - 369711 eventually trips at https://github.com/civicrm/civicrm-core/blob/master/CRM/Utils/Cache.php#L250. This patch cast the contribution ID to string before it is passed to cache get/set function which expects the parameter only to be string. 

