### PR TITLE
Extend Lineitem Edit form to support Financial Type change

### DIFF
--- a/CRM/Lineitemedit/Form/Edit.php
+++ b/CRM/Lineitemedit/Form/Edit.php
@@ -107,9 +107,6 @@ class CRM_Lineitemedit_Form_Edit extends CRM_Core_Form {
       }
 
       $ele = $this->addField($fieldName, $properties, $required);
-      if ($this->_lineitemInfo['entity_table'] != 'civicrm_contribution' && $fieldName == 'financial_type_id') {
-        $ele->freeze();
-      }
     }
     $this->assign('fieldNames', $fieldNames);
 

--- a/CRM/Lineitemedit/Util.php
+++ b/CRM/Lineitemedit/Util.php
@@ -736,6 +736,19 @@ ORDER BY  ps.id, pf.weight ;
       $values['deferred_line_item']['financial_item_id'] = $ftItem->id;
       self::createDeferredTrxn($contributionId, $values['deferred_line_item'], 'UpdateLineItem');
     }
+
+    $changeFinancialType = TRUE;
+    // find the total number of lineitem
+    $totalLineItem = civicrm_api3('LineItem', 'getcount', ['contribution_id' => $contributionId]);
+    //CRM_Core_Error::debug_var($totalLineItem, )
+    // if the contribtuion contain multiple line-items
+    if ($totalLineItem > 1) {
+      // if the total number of line-items is associated with multiple financial type then set $changeFinancialType to FALSE i.e. don't change the contribtuion's financial type
+      $changeFinancialType = (civicrm_api3('LineItem', 'getcount', ['contribution_id' => $contributionId, 'financial_type_id' => $newLineItem['financial_type_id']]) == $totalLineItem);
+    }
+    if ($changeFinancialType) {
+      civicrm_api3('Contribution', 'create', ['id' => $contributionId, 'financial_type_id' => $newLineItem['financial_type_id']]);
+    }
   }
 
   public static function createFinancialTrxnEntry($contributionId, $amount, $toFinancialAccount = NULL) {

--- a/CRM/Lineitemedit/Util.php
+++ b/CRM/Lineitemedit/Util.php
@@ -712,8 +712,10 @@ ORDER BY  ps.id, pf.weight ;
     );
     $trxnArray[2]['financial_account_id'] = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($newLineItem['financial_type_id'], $accountRelName);
 
-    $accountRelationship = empty($contribution['revenue_recognition_date']) ? 'Income Account is' : 'Deferred Revenue Account is';
-    $trxnArray[1]['to_financial_account_id'] = $trxnArray[2]['to_financial_account_id'] = $newFinancialAccount = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($newLineItem['financial_type_id'], $accountRelationship);
+    // previous to_financial_account_id
+    $trxnArray[1]['to_financial_account_id'] = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialTrxn', CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($contributionId, 'DESC')['financialTrxnId'], 'to_financial_account_id');
+    // retrieve linked financial account for payment instrument
+    $trxnArray[2]['to_financial_account_id'] = CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount($contribution['payment_instrument_id']);
 
     $financialItem['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Financial_DAO_FinancialItem', 'status_id', 'Paid');
     foreach ($trxnArray as $values) {

--- a/tests/phpunit/CRM/Lineitemedit/Form/EditTest.php
+++ b/tests/phpunit/CRM/Lineitemedit/Form/EditTest.php
@@ -168,6 +168,9 @@ class CRM_Lineitemedit_Form_EditTest extends CRM_Lineitemedit_Form_BaseTest {
     $lineItemInfo['financial_type_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Campaign Contribution');
     $form->testSubmit($lineItemInfo);
 
+    $contribution = $this->callAPISuccessGetSingle('Contribution', array('id' => $this->_contributionID));
+    $this->assertEquals($lineItemInfo['financial_type_id'], $contribution['financial_type_id']);
+
     $actualFinancialItemEntries = $this->getFinancialItemsByContributionID($this->_contributionID);
     $prevFinancialAccountID = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($this->_contribution['financial_type_id'], 'Income Account is');
     $newFinancialAccountID = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($lineItemInfo['financial_type_id'], 'Income Account is');

--- a/tests/phpunit/CRM/Lineitemedit/Form/SaleTax/EditTest.php
+++ b/tests/phpunit/CRM/Lineitemedit/Form/SaleTax/EditTest.php
@@ -331,6 +331,9 @@ class CRM_Lineitemedit_Form_SaleTax_EditTest extends CRM_Lineitemedit_Form_BaseT
     $lineItemInfo['tax_amount'] = $lineItemInfo['tax_amount'];
     $form->testSubmit($lineItemInfo);
 
+    $contribution = $this->callAPISuccessGetSingle('Contribution', array('id' => $contribution['id']));
+    $this->assertEquals($lineItemInfo['financial_type_id'], $contribution['financial_type_id']);
+
     $actualFinancialItemEntries = $this->getFinancialItemsByLineItemID($lineItemInfo['id']);
 
     $prevFinancialAccountID = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($this->_financialTypeID, 'Income Account is');


### PR DESCRIPTION
This PR extends the support on Lineitem edit page, where you can now change Financial type and on submit handles the financial items. 

Financial Type change for single-line-item backoffice contribution:  
![lineitemedit-1](https://user-images.githubusercontent.com/3735621/87661826-ea5d2100-c77e-11ea-94c0-2087c67b5fc7.gif)


Financial Type change for multi-line-item backoffice contribution:  
![lineitemedit](https://user-images.githubusercontent.com/3735621/87661841-f47f1f80-c77e-11ea-8457-a63ea09600d7.gif)

Added unit tests (including SaleTax usecases). 
